### PR TITLE
added message logging (delete update) #52

### DIFF
--- a/Events/Guild/messageDelete.ts
+++ b/Events/Guild/messageDelete.ts
@@ -1,0 +1,44 @@
+import Discord from 'discord.js';
+import EmbedGenerator from '../../Functions/embedGenerator.ts';
+import { GuildsManager } from '../../Classes/GuildsManager.ts';
+
+export default {
+    name: 'messageDelete',
+    /**
+     * @param {Discord.Message | Discord.PartialMessage} message
+     */
+    async execute(message: Discord.Message | Discord.PartialMessage) {
+        if (!message.guild) return;
+
+        let resolvedMessage = message;
+        if (message.partial) {
+            resolvedMessage = await message.fetch().catch(() => message);
+        }
+
+        if (resolvedMessage.author?.bot) return;
+
+        const guild = await GuildsManager.fetch(resolvedMessage.guild.id);
+        if (!guild?.logs.enabled || !guild.logs.basic_logs) return;
+
+        const logChannel = await resolvedMessage.guild.channels.fetch(guild.logs.basic_logs);
+        if (!logChannel || !(logChannel instanceof Discord.TextChannel)) return;
+
+        const author = resolvedMessage.author
+            ? `${resolvedMessage.author} (${resolvedMessage.author.id})`
+            : 'Unknown';
+        const channel = resolvedMessage.channelId ? `<#${resolvedMessage.channelId}>` : 'Unknown';
+        const content = resolvedMessage.content || '*Unknown (message was not cached)*';
+
+        logChannel.send({
+            embeds: [
+                EmbedGenerator.basicEmbed(
+                    [`• User: ${author}`, `• Channel: ${channel}`, `• Content: ${content}`].join(
+                        '\n'
+                    )
+                )
+                    .setTitle('Message Deleted')
+                    .setTimestamp(),
+            ],
+        });
+    },
+};

--- a/Events/Guild/messageUpdate.ts
+++ b/Events/Guild/messageUpdate.ts
@@ -1,0 +1,59 @@
+import Discord from 'discord.js';
+import EmbedGenerator from '../../Functions/embedGenerator.ts';
+import { GuildsManager } from '../../Classes/GuildsManager.ts';
+
+export default {
+    name: 'messageUpdate',
+    /**
+     * @param {Discord.Message | Discord.PartialMessage} oldMessage
+     * @param {Discord.Message | Discord.PartialMessage} newMessage
+     */
+    async execute(
+        oldMessage: Discord.Message | Discord.PartialMessage,
+        newMessage: Discord.Message | Discord.PartialMessage
+    ) {
+        if (!newMessage.guild) return;
+
+        let resolvedNew = newMessage;
+        if (newMessage.partial) {
+            resolvedNew = await newMessage.fetch().catch(() => newMessage);
+        }
+        if (resolvedNew.author?.bot) return;
+
+        let resolvedOld = oldMessage;
+        if (oldMessage.partial) {
+            resolvedOld = await oldMessage.fetch().catch(() => oldMessage);
+        }
+
+        const oldContent = resolvedOld.content ?? null;
+        const newContent = resolvedNew.content ?? null;
+        if (oldContent === newContent) return;
+
+        const guild = await GuildsManager.fetch(resolvedNew.guild.id);
+        if (!guild?.logs.enabled || !guild.logs.basic_logs) return;
+
+        const logChannel = await resolvedNew.guild.channels.fetch(guild.logs.basic_logs);
+        if (!logChannel || !(logChannel instanceof Discord.TextChannel)) return;
+
+        const author = resolvedNew.author
+            ? `${resolvedNew.author} (${resolvedNew.author.id})`
+            : 'Unknown';
+        const channel = resolvedNew.channelId ? `<#${resolvedNew.channelId}>` : 'Unknown';
+
+        logChannel.send({
+            embeds: [
+                EmbedGenerator.basicEmbed(
+                    [
+                        `• User: ${author}`,
+                        `• Channel: ${channel}`,
+                        `• Before: ${oldContent || '*Unknown (message was not cached)*'}`,
+                        `• After: ${newContent || '*Unknown (message was not cached)*'}`,
+                    ].join('\n')
+                )
+                    .setTitle('Message Edited')
+                    .setURL(resolvedNew.url)
+                    .setTimestamp(),
+            ],
+        });
+    },
+};


### PR DESCRIPTION
* Added a `messageDelete` event handler (`Events/Guild/messageDelete.ts`) that logs details of deleted messages—including user, channel, and content—to the guild's log channel, handling both cached and uncached messages.
* Added a `messageUpdate` event handler (`Events/Guild/messageUpdate.ts`) that logs before-and-after content of edited messages, including user and channel information, and posts this to the log channel if logging is enabled. The handler also properly resolves partial messages to ensure accurate logging.