### PR TITLE
Correct field name for basic_logs in setup checks

### DIFF
--- a/Commands/Administrator/setup.ts
+++ b/Commands/Administrator/setup.ts
@@ -36,7 +36,7 @@ const SETUP_STEPS: SetupStep[] = [
         id: 2,
         label: 'Basic log channel',
         warningOnFailure: false,
-        check: (g) => !!g?.logs?.basic,
+        check: (g) => !!g?.logs?.basic_logs,
     },
     {
         id: 3,
@@ -262,7 +262,7 @@ function generateEmbed(count: number, completed: number[], dbGuild: any) {
 
 function getSetupComponents(dbGuild: any): ActionRowBuilder<ButtonBuilder>[] {
     const needsLogging =
-        !dbGuild?.logs?.basic ||
+        !dbGuild?.logs?.basic_logs ||
         !dbGuild?.logs?.moderator ||
         !dbGuild?.logs?.suggestionsChannel ||
         !dbGuild?.logs?.announcementChannel ||


### PR DESCRIPTION
typo in setup.ts causing Basic log channel to always show as not configured
<img width="300" height="350" alt="{0A183E2A-CD85-410E-830B-DE06D63DCBA1}" src="https://github.com/user-attachments/assets/8873ffcb-0d02-462a-9086-cfd08ec3dadc" />

