### PR TITLE
Fix bot invite link permissions and use dynamic client ID

### DIFF
--- a/Commands/Information/invite.ts
+++ b/Commands/Information/invite.ts
@@ -12,7 +12,7 @@ export default {
         return {
             embeds: [
                 EmbedGenerator.basicEmbed(
-                    `[Click me for the invite to the bot!](https://discord.com/oauth2/authorize?client_id=1469385720270426358&scope=bot)`
+                    `[Click me for the invite to the bot!](https://discord.com/oauth2/authorize?client_id=1469385720270426358&permissions=8&integration_type=0&scope=bot)`
                 ),
             ],
         };

--- a/Commands/Information/invite.ts
+++ b/Commands/Information/invite.ts
@@ -12,7 +12,7 @@ export default {
         return {
             embeds: [
                 EmbedGenerator.basicEmbed(
-                    `[Click me for the invite to the bot!](https://discord.com/oauth2/authorize?client_id=1469385720270426358&permissions=8&integration_type=0&scope=bot)`
+                    `[Click me for the invite to the bot!](https://discord.com/oauth2/authorize?client_id=${_client.user?.id}&permissions=8&integration_type=0&scope=bot)`
                 ),
             ],
         };


### PR DESCRIPTION
* The invite link now uses the actual client ID from `_client.user?.id` instead of a hardcoded value, ensuring the correct bot is always referenced. 
* Updated the invite link to include `permissions=8` and `integration_type=0` to ensure correct installation and permission setup.