### PR TITLE
Enforce single vote and update poll message embed

### DIFF
--- a/Commands/Administrator/poll.ts
+++ b/Commands/Administrator/poll.ts
@@ -213,11 +213,7 @@ export default {
                         votes[i] = 0;
                     }
                 }
-
-                const totalVotes = Object.values(votes).reduce((a, b) => a + b, 0);
-                if (totalVotes > 0) {
-                    await pollMessage.edit({ embeds: [buildPollEmbed(votes)] });
-                }
+                await pollMessage.edit({ embeds: [buildPollEmbed(votes)] });
             } catch (error) {
                 console.error('Error updating poll:', error);
             }

--- a/Commands/Administrator/poll.ts
+++ b/Commands/Administrator/poll.ts
@@ -225,6 +225,17 @@ export default {
 
         const reactionAddListener = async (reaction: MessageReaction, user: User) => {
             if (reaction.message.id !== pollMessage.id || user.bot) return;
+
+            for (const [, existingReaction] of pollMessage.reactions.cache) {
+                if (existingReaction.emoji.name === reaction.emoji.name) continue;
+                const emojiIndex = numberEmojis.indexOf(existingReaction.emoji.name!);
+                if (emojiIndex === -1) continue;
+                const users = await existingReaction.users.fetch();
+                if (users.has(user.id)) {
+                    await existingReaction.users.remove(user.id);
+                }
+            }
+
             await updateVotes();
         };
 


### PR DESCRIPTION
* Added logic to the `reactionAddListener` function so that when a user reacts to a poll, any previous reactions they made to other poll options are removed, ensuring only one vote per user. (rapid reactions can clear all user reactions, couldn't fix it)
* Simplified the vote updating process by removing the check for `totalVotes > 0`, so the poll embed is always updated when reactions change.
<img width="300" height="450" alt="{A67F98E6-9BF5-47AA-A20E-6760D47D4308}" src="https://github.com/user-attachments/assets/92c8600a-df2d-4fd5-bf16-40add9d5c023" />
